### PR TITLE
Fix typo in "unknown target" error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1114,7 +1114,7 @@ fn default_cfg(target: &str) -> Vec<(String, Option<String>)> {
     } else if target.contains("vxworks") {
         ("vxworks", "unix", "")
     } else {
-        panic!("unknown os/family width: {}", target)
+        panic!("unknown os/family: {}", target)
     };
 
     ret.push((family.to_string(), None));


### PR DESCRIPTION
The 'width' mention is misleading in this context.